### PR TITLE
support nested directories for data-template attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,8 @@ Tests are stored in `./test` directory.
 gulp test
 ```
 
+### Templates from nested directories
+Templates can be loaded from nested directories via `data-template` attribute by replacing `/` with two subsequent dashes `--`, e.g. `directory--template-file`.
+
 ### ToDo
 - Write Tests for custom template file and name `{ file: 'path/to/file', name 'custom-file-template' }`

--- a/dist/kendo-template-loader.js
+++ b/dist/kendo-template-loader.js
@@ -53,9 +53,13 @@ var KendoTemplateLoader = (function () {
     };
     KendoTemplateLoader.prototype.loadTemplate = function (name, file) {
         file = file || name;
+        file = file.split('--').join('/');
         var that = this;
         var dfd = $.Deferred();
-        $.get(this.getTemplateFilePath(file))
+        $.ajax({
+            url: this.getTemplateFilePath(file),
+            dataType: 'html'
+        })
             .then(function (data) {
             data = data.trim();
             that.writeTemplate(name, data);

--- a/src/kendo-template-loader.ts
+++ b/src/kendo-template-loader.ts
@@ -62,11 +62,15 @@ class KendoTemplateLoader {
 
 	loadTemplate(name: string, file?: string): JQueryPromise<string> {
 		
-    file = file || name;
+    	file = file || name;
+    	file = file.split('--').join('/');
 		var that = this;
 		var dfd = $.Deferred();
 
-		$.get(this.getTemplateFilePath(file))
+		$.ajax({
+			url: this.getTemplateFilePath(file),
+			dataType: 'html'
+		})
 		.then(function(data: string) {
 			data = data.trim();
             that.writeTemplate(name, data);
@@ -76,7 +80,7 @@ class KendoTemplateLoader {
                 });
 			
 		})
-            .fail(function (e) {
+        .fail(function (e) {
 			dfd.reject(e);
 		});
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -14,6 +14,7 @@ describe('kendo-template-loader', function() {
 			done();
 		})
 		.fail(function(e) {
+			console.log(e);
 			throw new Error('fixture template "unknown" not found');
 			done();
 		});

--- a/test/fixtures/templates/nested/nested-item.html
+++ b/test/fixtures/templates/nested/nested-item.html
@@ -1,0 +1,1 @@
+<div>Nested Item</div>

--- a/test/nested.js
+++ b/test/nested.js
@@ -1,0 +1,19 @@
+describe('kendo-template-loader nested templates', function() {
+
+	var ktl;
+	beforeEach(function() {
+		ktl = new KendoTemplateLoader();
+		$('script[type="text/x-kendo-template"]').remove();
+	});
+
+	it('should be able to load templates from a subdirectory with -- delimiter', function(done) {
+
+		$.when(ktl.getTemplate('nested--nested-item'))
+		.done(function(data) {
+			expect(data).to.be.equal('<div>Nested Item</div>');
+			done();
+		});
+
+	});
+
+});

--- a/test/runner.html
+++ b/test/runner.html
@@ -21,6 +21,7 @@
     <script src="main.js"></script>
     <script src="basic.js"></script>
     <script src="recursion.js"></script>
+    <script src="nested.js"></script>
     <script type="text/javascript">
 	    mocha.run();
     </script>


### PR DESCRIPTION
Templates can be loaded from subdirectories by replacing the `/` by `--` when using `data-template` attributes.
